### PR TITLE
Added volume support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,23 @@ LABEL                                                                      \
 
 # -- BOINC ---------------------------------------------------------------
 
-RUN apt-get update &&                           \
-    apt-get -q install -y boinc-client &&       \
-    apt-get clean &&                            \
-    rm -rf /var/lib/apt/lists/*
+ENV GOSU_VERSION 1.9
+RUN set -x \
+    && apt-get update && apt-get install -y --no-install-recommends boinc-client ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+    && apt-get purge -y --auto-remove wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-USER boinc
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE    \
     31416 \
@@ -25,4 +36,5 @@ EXPOSE    \
 
 WORKDIR /var/lib/boinc-client
 
-ENTRYPOINT ["boinc"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["boinc"]

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ tool. See its [documentation][1] for usage details.
 See also the `docker-boinccmd` repo for a dockerized version of
 `boinccmd` and usage examples.
 
+### Data persistence
+
+To persist data add the `-v /path/to/host/directory:/var/lib/boinc-client` flag to the `docker run` command
+
 ## Possible Improvements ?
 
- * Use volumes to grab startup config.
- * Use volumes to persist work data and config between execution.
  * Provide some preset startup scripts.
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eo pipefail
+
+# if command starts with an option, prepend boinc 
+if [ "${1:0:1}" = '-' ]; then
+	set -- boinc "$@"
+fi
+
+if [ "$1" = 'boinc' ]; then
+    #fix permissions
+    chown -R boinc:boinc /var/lib/boinc-client
+    #reconfigure boinc just in case /var/lib/boinc-client is a volume and hasn't been used before
+    dpkg-reconfigure boinc-client
+    exec gosu boinc "$@"
+else
+    exec "$@"
+fi
+


### PR DESCRIPTION
- Added docker-entrypoint.sh which allows running docker run with an arbitary command (no need for --entrypoint=)
- Run chown -R boinc:boinc /var/lib/boinc on start to ensure correct permissions
- Run dpkg-reconfigure boinc-client on start to ensure symlinks are present
- Added gosu to allow running commands as root then running boinc as the boinc user
