### PR TITLE
/dev/input/mice error workaround and documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,37 @@ See also the `docker-boinccmd` repo for a dockerized version of
 
 To persist data add the `-v /path/to/host/directory:/var/lib/boinc-client` flag to the `docker run` command
 
+### Configuration persistence
+
+To use a persistent configuration you can either mount `/etc/boinc-client` as a volume or you can mount /var/lib/boinc-client
+as a volume and add your configuration files to that directory. 
+
+If you want to extract the default configuration files run the container without a volume and run `docker cp boinc:/etc/boinc-client /path/to/copy/to`
+
+### Virtualbox
+
+Some boinc projects use Virtualbox. Virtualbox isn't installed in this image due to size and techinical complications.
+
+If you wish to use Virtualbox then first on the host machine you need to install Virtualbox and Virtualbox kernel module
+See here https://www.virtualbox.org/wiki/Linux_Downloads for details of installing.
+
+Next you need to install **the same version** of Virtualbox in your container, to do this creata a docker file which
+contains the following:
+
+```
+FROM laurentmalvert/docker-boinc
+RUN apt-get update \
+    && apt-get -y install wget \
+    && wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | apt-key add - \
+    && echo 'deb http://download.virtualbox.org/virtualbox/debian jessie contrib' >> /etc/apt/sources.list \
+    && apt-get update && apt-get -y install virtualbox-5.1
+```
+
+Replacing `virtualbox-5.1` with whatever version you installed on your host machine.
+
+You then need to add the `--device=/dev/vboxdrv` flag to your docker run command i.e. 
+`/usr/bin/docker run --device=/dev/vboxdrv --name boinc yourimage --allow_remote_gui_rpc`
+
 ## Possible Improvements ?
 
  * Provide some preset startup scripts.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'boinc' ]; then
+    #work around for activity checking which sends errors to stderr if this directory doesn't exist
+    mkdir -p /dev/input/mice
     #fix permissions
     chown -R boinc:boinc /var/lib/boinc-client
     #reconfigure boinc just in case /var/lib/boinc-client is a volume and hasn't been used before


### PR DESCRIPTION
@laurent-malvert thanks for creating this repo, I've had some fun playing with it. I've added some documentation for users that want to use virtualbox with boinc and about persistent configuration and added a fix for an error about /dev/input/mice not being read.
